### PR TITLE
fixed last example

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1603,6 +1603,7 @@ using the :meth:`loop.add_signal_handler` method::
 
     def ask_exit(signame):
         print("got signal %s: exit" % signame)
+        loop = asyncio.get_running_loop()
         loop.stop()
 
     async def main():


### PR DESCRIPTION
(trivial docs fix) Before this patch (of the last one example) the following error occurred on Ctrl+C:
^Cgot signal SIGINT: exit
Exception in callback ask_exit('SIGINT')() at /tmp/test_async_signal.py:6
handle: <Handle ask_exit('SIGINT')() at /tmp/test_async_signal.py:6>
Traceback (most recent call last):
  File "/usr/lib/python3.7/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/tmp/test_async_signal.py", line 8, in ask_exit
    loop = asyncio.get_running_loop()
NameError: name 'loop' is not defined

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
